### PR TITLE
Initiate models after updates

### DIFF
--- a/app/Models/Attendee.php
+++ b/app/Models/Attendee.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Attendee extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'user_event_id'
+    ];
+
+    public function userEvent() {
+        return $this->belongsTo('App\Models\UserEvent');
+    }
+}

--- a/app/Models/UserEvent.php
+++ b/app/Models/UserEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class UserEvent extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'link',
+        'date',
+        'user_id',
+        'location',
+        'duration',
+        'password',
+        'user_event_status_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'date' => 'datetime',
+    ];
+
+
+    public function host() {
+        return $this->belongsTo('App\Models\User', 'user_id', 'id');
+    }
+
+    public function attendees() {
+        return $this->hasMany('App\Models\Attendee');
+    }
+
+    public function status() {
+        return $this->belongsTo('App\Models\UserEventStatus', 'user_event_status_id', 'id');
+    }
+}

--- a/app/Models/UserEvent.php
+++ b/app/Models/UserEvent.php
@@ -16,12 +16,13 @@ class UserEvent extends Model
      */
     protected $fillable = [
         'name',
-        'link',
         'date',
         'user_id',
-        'location',
         'duration',
         'password',
+        'calendly_link',
+        'third_party_link',
+        'third_party_name',
         'user_event_status_id',
     ];
 

--- a/app/Models/UserEventStatus.php
+++ b/app/Models/UserEventStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class UserEventStatus extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = ['name'];
+
+    public function events() {
+        return $this->hasMany('App\Models\UserEvent', 'user_event_status_id', 'id');
+    }
+}

--- a/database/migrations/2023_01_20_061212_create_user_event_statuses_table.php
+++ b/database/migrations/2023_01_20_061212_create_user_event_statuses_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePasswordResetsTable extends Migration
+class CreateUserEventStatusesTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,10 +13,11 @@ class CreatePasswordResetsTable extends Migration
      */
     public function up()
     {
-        Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
-            $table->string('token');
-            $table->timestamp('created_at')->nullable();
+        Schema::create('user_event_statuses', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+            $table->softDeletes();
         });
     }
 
@@ -27,6 +28,6 @@ class CreatePasswordResetsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('password_resets');
+        Schema::dropIfExists('user_event_statuses');
     }
 }

--- a/database/migrations/2023_01_20_061239_create_user_events_table.php
+++ b/database/migrations/2023_01_20_061239_create_user_events_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_events', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->dateTime('date');
+            $table->string('location');
+            $table->integer('duration');
+            $table->string('link')->index();
+            $table->string('password')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->unsignedInteger('user_event_status_id')->index();
+            $table->foreign('user_event_status_id')->references('id')->on('user_event_statuses');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_events');
+    }
+}

--- a/database/migrations/2023_01_20_061239_create_user_events_table.php
+++ b/database/migrations/2023_01_20_061239_create_user_events_table.php
@@ -17,13 +17,14 @@ class CreateUserEventsTable extends Migration
             $table->bigIncrements('id');
             $table->string('name');
             $table->dateTime('date');
-            $table->string('location');
             $table->integer('duration');
-            $table->string('link')->index();
+            $table->string('third_party_name');
             $table->string('password')->nullable();
+            $table->string('calendly_link')->index();
+            $table->string('third_party_link')->index();
+            $table->unsignedInteger('user_event_status_id')->index();
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->foreign('user_id')->references('id')->on('users');
-            $table->unsignedInteger('user_event_status_id')->index();
             $table->foreign('user_event_status_id')->references('id')->on('user_event_statuses');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2023_01_20_065007_create_attendees_table.php
+++ b/database/migrations/2023_01_20_065007_create_attendees_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUsersTable extends Migration
+class CreateAttendeesTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,14 +13,15 @@ class CreateUsersTable extends Migration
      */
     public function up()
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('attendees', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+            $table->string('email');
+            $table->string('notes')->nullable();
+            $table->unsignedBigInteger('user_event_id')->index();
+            $table->foreign('user_event_id')->references('id')->on('user_events');
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 
@@ -31,6 +32,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('attendees');
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
         $this->call(UsersTableSeeder::class);
+        $this->call(UserEventStatusSeeder::class);
     }
 }

--- a/database/seeders/UserEventStatusSeeder.php
+++ b/database/seeders/UserEventStatusSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\UserEventStatus;
+use Illuminate\Database\Seeder;
+
+class UserEventStatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // define all statuses needed for user events
+        // separate statuses to enable search with index
+        // ex: select all events where status === 1 (pending)
+        $statuses = [
+            ['name' => 'pending'],
+            ['name' => 'up coming']
+        ];
+
+        UserEventStatus::insert($statuses);
+    }
+}


### PR DESCRIPTION
The best practice to update migration columns is to create `add` migrations to just add columns
but since this project doesn't deploy yet so I can update the existing migrations without any errors